### PR TITLE
Update Ex10.scala

### DIFF
--- a/src/main/scala/com/basile/scala/ch03/Ex10.scala
+++ b/src/main/scala/com/basile/scala/ch03/Ex10.scala
@@ -15,9 +15,8 @@ import java.awt.datatransfer._
  */
 object Ex10 extends App {
 
-  val flavors = SystemFlavorMap.getDefaultFlavorMap().asInstanceOf[SystemFlavorMap]
-
-  val flavorsBuffer : Buffer[String] = flavors.getNativesForFlavor(DataFlavor.imageFlavor)
+  val flavors = SystemFlavorMap.getDefaultFlavorMap.asInstanceOf[SystemFlavorMap]
+  val flavorBuffer: Buffer[String] = JavaConverters.asScalaBufferConverter(flavors.getNativesForFlavor(DataFlavor.imageFlavor)).asScala
 
   flavorsBuffer.foreach(println)
 


### PR DESCRIPTION
The proposed implementation is missing the needed JavaConverter, without it the code won't compile. In this version the code correctly converts the java.util.List to mutable.Buffer.
