### PR TITLE
Fixed typo in HTML table construction

### DIFF
--- a/src/main/scala/com/basile/scala/ch11/Ex05.scala
+++ b/src/main/scala/com/basile/scala/ch11/Ex05.scala
@@ -20,7 +20,7 @@ object Ex05 extends App {
       items += ArrayBuffer(s)
       this
     }
-    override def toString = items.map(_.mkString("<td>", "<td></td>", "</td>")).mkString("<table><tr>", "</tr><tr>", "</tr></table>")
+    override def toString = items.map(_.mkString("<td>", "</td><td>", "</td>")).mkString("<table><tr>", "</tr><tr>", "</tr></table>")
   }
 
   object Table {


### PR DESCRIPTION
The mkString instruction in &lt;td&gt; construction was wrong: it was _.mkString("&lt;td&gt;", "&lt;td&gt;&lt;/td&gt;", "&lt;/td&gt;"). Thus, the final result was like this: &lt;table&gt;&lt;tr&gt;&lt;td&gt;Java&lt;td&gt;&lt;/td&gt;Scala&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Gosling ecc...
Instead, it had to be _.mkString("&lt;td&gt;", "&lt;/td&gt;&lt;td&gt;", "&lt;/td&gt;")
